### PR TITLE
Added variable check to remove notice

### DIFF
--- a/includes/wp-apple-touch-icons-common.php
+++ b/includes/wp-apple-touch-icons-common.php
@@ -12,6 +12,8 @@ if ( ! class_exists( 'WP_ATI_Common' ) ) {
 		public static function add_apple_icons( $meta_tags ) {
 			global $post;
 
+			if ( ! $post ) return $meta_tags;
+
 			$icon = get_post_meta( $post->ID, 'wp_ati_icon', true );
 
 			if ( ! $icon ) {


### PR DESCRIPTION
Bug Fixes:
* Removed the pesky notice that `$post` is not defined when the plugin runs on a page that isn't a post specific template.